### PR TITLE
Tweaks 'genConstruction' (tested)

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -134,3 +134,19 @@ jobs:
         docker exec -t test bundle update
         docker exec -t test bundle exec rake
         docker kill test
+  test_310x:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check out repository
+      uses: actions/checkout@v2
+    - name: Run Tests
+      run: |
+        echo $(pwd)
+        echo $(ls)
+        docker pull nrel/openstudio:3.10.0
+        docker run --name test --rm -d -t -v $(pwd):/work -w /work nrel/openstudio:3.10.0
+        docker exec -t test pwd
+        docker exec -t test ls
+        docker exec -t test bundle update
+        docker exec -t test bundle exec rake
+        docker kill test

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -22,38 +22,6 @@ jobs:
         docker exec -t test bundle update
         docker exec -t test bundle exec rake
         docker kill test
-  test_330x:
-    runs-on: ubuntu-22.04
-    steps:
-    - name: Check out repository
-      uses: actions/checkout@v2
-    - name: Run Tests
-      run: |
-        echo $(pwd)
-        echo $(ls)
-        docker pull nrel/openstudio:3.3.0
-        docker run --name test --rm -d -t -v $(pwd):/work -w /work nrel/openstudio:3.3.0
-        docker exec -t test pwd
-        docker exec -t test ls
-        docker exec -t test bundle update
-        docker exec -t test bundle exec rake
-        docker kill test
-  test_340x:
-    runs-on: ubuntu-22.04
-    steps:
-    - name: Check out repository
-      uses: actions/checkout@v2
-    - name: Run Tests
-      run: |
-        echo $(pwd)
-        echo $(ls)
-        docker pull nrel/openstudio:3.4.0
-        docker run --name test --rm -d -t -v $(pwd):/work -w /work nrel/openstudio:3.4.0
-        docker exec -t test pwd
-        docker exec -t test ls
-        docker exec -t test bundle update
-        docker exec -t test bundle exec rake
-        docker kill test
   test_351x:
     runs-on: ubuntu-22.04
     steps:
@@ -134,8 +102,8 @@ jobs:
         docker exec -t test bundle update
         docker exec -t test bundle exec rake
         docker kill test
-  test_310x:
-    runs-on: ubuntu-latest
+  test_3100x:
+    runs-on: ubuntu-22.04
     steps:
     - name: Check out repository
       uses: actions/checkout@v2

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,5 @@
 source "https://rubygems.org"
 
+gem "oslg", git: "https://github.com/rd2/oslg", branch: "v033"
+
 gemspec

--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,3 @@
 source "https://rubygems.org"
 
-gem "oslg", git: "https://github.com/rd2/oslg", branch: "v033"
-
 gemspec

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 BSD 3-Clause License
 
-Copyright (c) 2022-2024, Denis Bourgeois
+Copyright (c) 2022-2025, Denis Bourgeois
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/lib/osut.rb
+++ b/lib/osut.rb
@@ -1,6 +1,6 @@
 # BSD 3-Clause License
 #
-# Copyright (c) 2022-2024, Denis Bourgeois
+# Copyright (c) 2022-2025, Denis Bourgeois
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/lib/osut/utils.rb
+++ b/lib/osut/utils.rb
@@ -1,6 +1,6 @@
 # BSD 3-Clause License
 #
-# Copyright (c) 2022-2024, Denis Bourgeois
+# Copyright (c) 2022-2025, Denis Bourgeois
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/lib/osut/utils.rb
+++ b/lib/osut/utils.rb
@@ -4556,6 +4556,72 @@ module OSut
   end
 
   ##
+  # Fetch a space's full height (in space coordinates). The solution considers
+  # all surface types ("Floor" vs "Wall" vs "RoofCeiling").
+  #
+  # @param space [OpenStudio::Model::Space] a space
+  #
+  # @return [Float] full height of space (0 if invalid input)
+  def spaceHeight(space = nil)
+    return 0 unless space.is_a?(OpenStudio::Model::Space)
+
+    minZ = 1000
+    maxZ = 0
+
+    space.surfaces.each do |surface|
+      minZ = [surface.vertices.min_by(&:z).z, minZ].min
+      maxZ = [surface.vertices.max_by(&:z).z, maxZ].max
+    end
+
+    maxZ < minZ ? 0 : maxZ - minZ
+  end
+
+  ##
+  # Fetch a space's width, based on the geometry of space floors.
+  #
+  # @param space [OpenStudio::Model::Space] a space
+  #
+  # @return [Float] width of a space (0 if invalid input)
+  def spaceWidth(space = nil)
+    return 0 unless space.is_a?(OpenStudio::Model::Space)
+
+    floors = facets(space, "all", "Floor")
+    return 0 if floors.empty?
+
+    # Automatically determining a space's "width" is not straightforward:
+    #   - a space may hold multiple floor surfaces at various Z-axis levels
+    #   - a space may hold multiple floor surfaces, with unique "widths"
+    #   - a floor surface may expand/contract (in "width") along its length.
+    #
+    # First, attempt to merge all floor surfaces together as 1x polygon:
+    #   - select largest floor surface (in area)
+    #   - determine its 3D plane
+    #   - retain only other floor surfaces sharing same 3D plane
+    #   - recover potential union between floor surfaces
+    #   - fall back to largest floor surface if invalid union
+    floors = floors.sort_by(&:grossArea).reverse
+    floor  = floors.first
+    plane  = floor.plane
+    t      = OpenStudio::Transformation.alignFace(floor.vertices)
+    polyg  = poly(floor, false, true, true, t, :ulc).to_a.reverse
+    return 0 if polyg.empty?
+
+    if floors.size > 1
+      floors = floors.select { |flr| plane.equal(flr.plane, 0.001) }
+
+      if floors.size > 1
+        polygs = floors.map    { |flr| poly(flr, false, true, true, t, :ulc) }
+        polygs = polygs.reject { |plg| plg.empty? }
+        polygs = polygs.map    { |plg| plg.to_a.reverse }
+        union  = OpenStudio.joinAll(polygs, 0.01).first
+        polyg  = poly(union, false, true, true)
+      end
+    end
+
+    height(boundedBox(polyg))
+  end
+
+  ##
   # Identifies 'leader line anchors', i.e. specific 3D points of a (larger) set
   # (e.g. delineating a larger, parent polygon), each anchor linking the BLC
   # corner of one or more (smaller) subsets (free-floating within the parent)

--- a/lib/osut/utils.rb
+++ b/lib/osut/utils.rb
@@ -4615,10 +4615,14 @@ module OSut
         polygs = polygs.map    { |plg| plg.to_a.reverse }
         union  = OpenStudio.joinAll(polygs, 0.01).first
         polyg  = poly(union, false, true, true)
+        return 0 if polyg.empty?
       end
     end
 
-    height(boundedBox(polyg))
+    res = realignedFace(polyg.to_a.reverse)
+    return 0 if res[:box].nil?
+
+    height(res[:box])
   end
 
   ##

--- a/lib/osut/utils.rb
+++ b/lib/osut/utils.rb
@@ -4565,8 +4565,8 @@ module OSut
   def spaceHeight(space = nil)
     return 0 unless space.is_a?(OpenStudio::Model::Space)
 
-    minZ = 1000
-    maxZ = 0
+    minZ =  10000
+    maxZ = -10000
 
     space.surfaces.each do |surface|
       minZ = [surface.vertices.min_by(&:z).z, minZ].min
@@ -4599,6 +4599,7 @@ module OSut
     #   - retain only other floor surfaces sharing same 3D plane
     #   - recover potential union between floor surfaces
     #   - fall back to largest floor surface if invalid union
+    #   - return width of largest bounded box
     floors = floors.sort_by(&:grossArea).reverse
     floor  = floors.first
     plane  = floor.plane
@@ -4622,6 +4623,7 @@ module OSut
     res = realignedFace(polyg.to_a.reverse)
     return 0 if res[:box].nil?
 
+    # A bounded box's 'height', at its narrowest, is its 'width'.
     height(res[:box])
   end
 

--- a/lib/osut/version.rb
+++ b/lib/osut/version.rb
@@ -29,5 +29,5 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 module OSut
-  VERSION = "0.6.1".freeze # OSut version
+  VERSION = "0.7.0".freeze
 end

--- a/lib/osut/version.rb
+++ b/lib/osut/version.rb
@@ -1,6 +1,6 @@
 # BSD 3-Clause License
 #
-# Copyright (c) 2022-2024, Denis Bourgeois
+# Copyright (c) 2022-2025, Denis Bourgeois
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
@@ -29,5 +29,5 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 module OSut
-  VERSION = "0.6.0".freeze # OSut version
+  VERSION = "0.6.1".freeze # OSut version
 end

--- a/osut.gemspec
+++ b/osut.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |s|
   s.required_ruby_version     = [">= 2.5.0", "< 4"]
   s.metadata                  = {}
 
-  s.add_development_dependency  "oslg",    ">= 0.4.0"
+  s.add_dependency              "oslg",    ">= 0.4.0"
   s.add_development_dependency  "bundler", "~> 2.1"
   s.add_development_dependency  "rake",    "~> 13.0"
   s.add_development_dependency  "rspec",   "~> 3.11"

--- a/osut.gemspec
+++ b/osut.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |s|
   s.required_ruby_version     = [">= 2.5.0", "< 4"]
   s.metadata                  = {}
 
-  s.add_dependency              "oslg",    ">= 0.3.0"
+  s.add_development_dependency  "oslg",    ">= 0.4.0"
   s.add_development_dependency  "bundler", "~> 2.1"
   s.add_development_dependency  "rake",    "~> 13.0"
   s.add_development_dependency  "rspec",   "~> 3.11"

--- a/spec/osut_tests_spec.rb
+++ b/spec/osut_tests_spec.rb
@@ -1306,8 +1306,8 @@ RSpec.describe OSut do
     expect(schedule.setScheduleTypeLimits(limits)).to be true
 
     tvals = schedule.timeSeries.values
-    expect(tvals).is_a?(OpenStudio::Vector)
-    tvals.each { |tval| expect(tval.is_a?(Numeric)) }
+    expect(tvals).to be_a(OpenStudio::Vector)
+    tvals.each { |tval| expect(tval).to be_a(Numeric) }
 
     availability = M.availabilitySchedule(model)
 
@@ -2354,10 +2354,10 @@ RSpec.describe OSut do
     glazing = OpenStudio::Model::SubSurface.new(vec, model)
 
     # Glazing fits?, overlaps? parallel?
-    expect(mod1.parallel?(glazing, wall)).to be(true)
+    expect(mod1.parallel?(glazing, wall)).to be true
     expect(mod1.fits?(glazing, wall)).to be true
     expect(mod1.overlaps?(glazing, wall)).to be true
-    expect(mod1.parallel?(wall, glazing)).to be(true)
+    expect(mod1.parallel?(wall, glazing)).to be true
     expect(mod1.fits?(wall, glazing)).to be true
     expect(mod1.overlaps?(wall, glazing)).to be true
 
@@ -2510,7 +2510,7 @@ RSpec.describe OSut do
     # Overlap between roof and vertically-cast ceiling onto roof plane.
     olap02 = mod1.overlap(roof, cast02)
     expect(olap02.size).to eq(3) # not 5
-    expect(mod1.fits?(olap02, roof)).to be(true)
+    expect(mod1.fits?(olap02, roof)).to be true
 
     olap02.each { |pt| expect(pl2.pointOnPlane(pt)) }
 
@@ -2782,7 +2782,7 @@ RSpec.describe OSut do
 
     collinears = mod1.getCollinears( [p0, p1, p2, p3] )
     expect(collinears.size).to eq(1)
-    expect(mod1.same?(collinears[0], p1)).to be true
+    expect(mod1.same?(collinears.first, p1)).to be true
 
     # CASE a1: 2x end-to-end line segments (returns matching endpoints).
     expect(mod1.lineIntersects?(   [p0, p1], [p1, p2] )).to be true
@@ -2832,6 +2832,7 @@ RSpec.describe OSut do
     expect(mod1.pointWithinPolygon?(p5, [p0, p1, p2, p3])).to be true
     expect(mod1.pointWithinPolygon?(p6, [p0, p1, p2, p3])).to be false
     expect(mod1.pointWithinPolygon?(p7, [p0, p1, p2, p3])).to be true
+
     expect(mod1.status).to be_zero
 
     # --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- #
@@ -2848,6 +2849,7 @@ RSpec.describe OSut do
     expect(mod1.logs.first[:message]).to include("Empty 'plane'")
     expect(mod1.clean!).to eq(DBG)
 
+
     # Test self-intersecting polygon. If reactivated, OpenStudio logs to stdout:
     # [utilities.Transformation] <1> Cannot compute outward normal for vertices
     # vtx  = OpenStudio::Point3dVector.new
@@ -2855,11 +2857,11 @@ RSpec.describe OSut do
     # vtx << OpenStudio::Point3d.new( 0, 0, 10)
     # vtx << OpenStudio::Point3d.new(20, 0,  0)
     # vtx << OpenStudio::Point3d.new( 0, 0,  0)
-    #
-    # expect(mod1.poly(vtx)).to be_empty
-    # expect(mod1.status).to eq(ERR)
-    # expect(mod1.logs.size).to eq(1)
-    # expect(mod1.logs.first[:message]).to include("'(unaligned) points'")
+
+    # Original polygon remains unaltered.
+    # vtx2 = mod1.poly(vtx)
+    # expect(mod1.same?(vtx, vtx2)).to be true
+    # expect(mod1.status).to eq(0)
     # expect(mod1.clean!).to eq(DBG)
 
     # Regular polygon, counterclockwise yet not UpperLeftCorner (ULC).
@@ -5441,6 +5443,17 @@ RSpec.describe OSut do
     expect(surface).to be_a(OpenStudio::Model::Surface)
     expect(surface.vertices.size).to eq(12)
     expect(surface.grossArea).to be_within(TOL).of(5 * 20 - 1)
+
+    # --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- #
+    # Invalid input case.
+    plates = ["osut"]
+    slab = mod1.genSlab(plates, z0)
+    expect(mod1.debug?).to be true
+    expect(mod1.logs.size).to eq(1)
+    expect(mod1.logs.first[:message]).to include("String? expecting Hash")
+    expect(slab).to be_a(OpenStudio::Point3dVector)
+    expect(slab).to be_empty
+
   end
 
   it "checks roller shades" do

--- a/spec/osut_tests_spec.rb
+++ b/spec/osut_tests_spec.rb
@@ -1914,7 +1914,7 @@ RSpec.describe OSut do
     pts = r * a
     expect(mod1.same?(pts, vtx)).to be true
 
-    output1 = mod1.getRealignedFace(vtx)
+    output1 = mod1.realignedFace(vtx)
     expect(mod1.status).to be_zero
     expect(output1).to be_a Hash
     expect(output1).to have_key(:set)
@@ -1928,7 +1928,7 @@ RSpec.describe OSut do
     ubbox1 = output1[:bbox]
 
     # Realign a previously realigned surface?
-    output2 = mod1.getRealignedFace(output1[:box])
+    output2 = mod1.realignedFace(output1[:box])
     ubox2   = output1[ :box]
     ubbox2  = output1[:bbox]
 
@@ -1957,12 +1957,12 @@ RSpec.describe OSut do
     vtx << OpenStudio::Point3d.new(  5,  2,  0)
     vtx << OpenStudio::Point3d.new(  6,  4,  0)
 
-    output3 = mod1.getRealignedFace(vtx)
+    output3 = mod1.realignedFace(vtx)
     ubox3   = output3[ :box]
     ubbox3  = output3[:bbox]
 
     # Realign a previously realigned surface?
-    output4 = mod1.getRealignedFace(output3[:box])
+    output4 = mod1.realignedFace(output3[:box])
     ubox4   = output4[ :box]
     ubbox4  = output4[:bbox]
 
@@ -1993,12 +1993,12 @@ RSpec.describe OSut do
     vtx << OpenStudio::Point3d.new(  1,  4,  0)
     vtx << OpenStudio::Point3d.new(  2,  2,  0)
 
-    output5 = mod1.getRealignedFace(vtx)
+    output5 = mod1.realignedFace(vtx)
     ubox5   = output5[ :box]
     ubbox5  = output5[:bbox]
 
     # Realign a previously realigned surface?
-    output6 = mod1.getRealignedFace(output5[:box])
+    output6 = mod1.realignedFace(output5[:box])
     ubox6   = output6[ :box]
     ubbox6  = output6[:bbox]
 
@@ -2033,12 +2033,12 @@ RSpec.describe OSut do
     vtx << OpenStudio::Point3d.new(  2,  6,  0)
     vtx << OpenStudio::Point3d.new(  1,  4,  0)
 
-    output7 = mod1.getRealignedFace(vtx)
+    output7 = mod1.realignedFace(vtx)
     ubox7   = output7[ :box]
     ubbox7  = output7[:bbox]
 
     # Realign a previously realigned surface?
-    output8 = mod1.getRealignedFace(ubox7)
+    output8 = mod1.realignedFace(ubox7)
     ubox8   = output8[ :box]
     ubbox8  = output8[:bbox]
 
@@ -2073,11 +2073,11 @@ RSpec.describe OSut do
     vtx << OpenStudio::Point3d.new(  6,  2,  0)
     vtx << OpenStudio::Point3d.new(  6,  4,  0)
 
-    output9 = mod1.getRealignedFace(vtx)
+    output9 = mod1.realignedFace(vtx)
     ubox9   = output9[ :box]
     ubbox9  = output9[:bbox]
 
-    output10 = mod1.getRealignedFace(vtx, true) # no impact
+    output10 = mod1.realignedFace(vtx, true) # no impact
     ubox10   = output10[ :box]
     ubbox10  = output10[:bbox]
     expect(mod1.same?(ubox9, ubox10)).to be true
@@ -2090,11 +2090,11 @@ RSpec.describe OSut do
     vtx << OpenStudio::Point3d.new(  4,  2,  0)
     vtx << OpenStudio::Point3d.new(  4,  6,  0)
 
-    output11 = mod1.getRealignedFace(vtx)
+    output11 = mod1.realignedFace(vtx)
     ubox11   = output11[ :box]
     ubbox11  = output11[:bbox]
 
-    output12 = mod1.getRealignedFace(vtx, true) # narrow, now wide
+    output12 = mod1.realignedFace(vtx, true) # narrow, now wide
     ubox12   = output12[ :box]
     ubbox12  = output12[:bbox]
     expect(mod1.same?(ubox11, ubox12)).to be false
@@ -2110,14 +2110,14 @@ RSpec.describe OSut do
     vtx << OpenStudio::Point3d.new(  3,  8,  0)
     vtx << OpenStudio::Point3d.new(  1,  4,  0)
 
-    output13 = mod1.getRealignedFace(vtx)
+    output13 = mod1.realignedFace(vtx)
     uset13   = output13[ :set]
     ubox13   = output13[ :box]
     ubbox13  = output13[:bbox]
 
     # Pre-isolate bounded box (preferable with irregular surfaces).
     box      = mod1.boundedBox(vtx)
-    output14 = mod1.getRealignedFace(box)
+    output14 = mod1.realignedFace(box)
     uset14   = output14[ :set]
     ubox14   = output14[ :box]
     ubbox14  = output14[:bbox]
@@ -2226,20 +2226,20 @@ RSpec.describe OSut do
     sg2 << OpenStudio::Point3d.new(12, 14, 0)
     sg2 << OpenStudio::Point3d.new(12,  6, 0)
 
-    expect(mod1.getLineIntersection(sg1, sg2)).to be_nil
+    expect(mod1.lineIntersection(sg1, sg2)).to be_nil
 
     sg1 = OpenStudio::Point3dVector.new
     sg1 << OpenStudio::Point3d.new(0.60,19.06, 0)
     sg1 << OpenStudio::Point3d.new(0.60, 0.60, 0)
     sg1 << OpenStudio::Point3d.new(0.00, 0.00, 0)
     sg1 << OpenStudio::Point3d.new(0.00,19.66, 0)
-    sgs1 = mod1.getSegments(sg1)
+    sgs1 = mod1.segments(sg1)
 
     sg2 = OpenStudio::Point3dVector.new
     sg2 << OpenStudio::Point3d.new(9.83, 9.83, 0)
     sg2 << OpenStudio::Point3d.new(0.00, 0.00, 0)
     sg2 << OpenStudio::Point3d.new(0.00,19.66, 0)
-    sgs2 = mod1.getSegments(sg2)
+    sgs2 = mod1.segments(sg2)
 
     expect(mod1.same?(sg1[2], sg2[1])).to be true
     expect(mod1.same?(sg1[3], sg2[2])).to be true
@@ -2392,13 +2392,13 @@ RSpec.describe OSut do
     south   = south.get
 
     # Side test: triad, medial and bounded boxes.
-    pts   = mod1.getNonCollinears(ceiling.vertices, 3)
+    pts   = mod1.nonCollinears(ceiling.vertices, 3)
     box01 = mod1.triadBox(pts)
     box11 = mod1.boundedBox(ceiling)
     expect(mod1.same?(box01, box11)).to be true
     expect(mod1.fits?(box01, ceiling)).to be true
 
-    pts   = mod1.getNonCollinears(roof.vertices, 3)
+    pts   = mod1.nonCollinears(roof.vertices, 3)
     box02 = mod1.medialBox(pts)
     box12 = mod1.boundedBox(roof)
     expect(mod1.same?(box02, box12)).to be true
@@ -2841,19 +2841,19 @@ RSpec.describe OSut do
     expect(pt).to be_a(OpenStudio::Point3d)
     expect(pt).to eq(p0)
 
-    # Stress test 'getSegments'. Invalid case.
-    sgs = mod1.getSegments(p3)
+    # Stress test 'segments'. Invalid case.
+    sgs = mod1.segments(p3)
     expect(sgs).to be_a(OpenStudio::Point3dVectorVector)
     expect(sgs).to be_empty
     expect(mod1.status).to eq(0) # nothing logged
 
-    sgs = mod1.getSegments([p3, p3])
+    sgs = mod1.segments([p3, p3])
     expect(sgs).to be_a(OpenStudio::Point3dVectorVector)
     expect(sgs).to be_empty
     expect(mod1.status).to eq(0) # nothing logged
 
     # Valid case.
-    sgs = mod1.getSegments([p0, p1, p2, p3])
+    sgs = mod1.segments([p0, p1, p2, p3])
     expect(sgs).to be_a(OpenStudio::Point3dVectorVector)
     expect(sgs.size).to eq(4)
     expect(sgs).to respond_to(:first)
@@ -2861,10 +2861,10 @@ RSpec.describe OSut do
     expect(sgs[-1]).to be_an(Array) # not an OpenStudio::Point3dVector
 
     # Stress test 'uniques'.
-    m0 = "'n points' String? expecting Integer (OSut::getUniques)"
+    m0 = "'n points' String? expecting Integer (OSut::uniques)"
 
     # Invalid number case - simply returns entire list of unique points.
-    uniks = mod1.getUniques([p0, p1, p2, p3], "osut")
+    uniks = mod1.uniques([p0, p1, p2, p3], "osut")
     expect(uniks).to be_a(OpenStudio::Point3dVector)
     expect(uniks.size).to eq(4)
     expect(mod1.debug?).to be true
@@ -2873,95 +2873,95 @@ RSpec.describe OSut do
     expect(mod1.clean!).to eq(DBG)
 
     # Valid, basic case.
-    uniks = mod1.getUniques([p0, p1, p2, p3])
+    uniks = mod1.uniques([p0, p1, p2, p3])
     expect(uniks).to be_a(OpenStudio::Point3dVector)
     expect(uniks.size).to eq(4)
 
-    uniks = mod1.getUniques([p0, p1, p2, p3], 0)
+    uniks = mod1.uniques([p0, p1, p2, p3], 0)
     expect(uniks).to be_a(OpenStudio::Point3dVector)
     expect(uniks.size).to eq(4)
 
     # Valid, first 3 points.
-    uniks = mod1.getUniques([p0, p1, p2, p3], 3)
+    uniks = mod1.uniques([p0, p1, p2, p3], 3)
     expect(uniks).to be_a(OpenStudio::Point3dVector)
     expect(uniks.size).to eq(3)
 
     # Valid, last 3 points.
-    uniks = mod1.getUniques([p0, p1, p2, p3], -3)
+    uniks = mod1.uniques([p0, p1, p2, p3], -3)
     expect(uniks).to be_a(OpenStudio::Point3dVector)
     expect(uniks.size).to eq(3)
 
     # Valid, n = 5: returns original 4 uniques points.
-    uniks = mod1.getUniques([p0, p1, p2, p3], 5)
+    uniks = mod1.uniques([p0, p1, p2, p3], 5)
     expect(uniks).to be_a(OpenStudio::Point3dVector)
     expect(uniks.size).to eq(4)
 
     # Valid, n = -5: returns original 4 uniques points.
-    uniks = mod1.getUniques([p0, p1, p2, p3], -5)
+    uniks = mod1.uniques([p0, p1, p2, p3], -5)
     expect(uniks).to be_a(OpenStudio::Point3dVector)
     expect(uniks.size).to eq(4)
 
     # Stress tests collinears.
-    m0 = "'n points' String? expecting Integer (OSut::getCollinears)"
+    m0 = "'n points' String? expecting Integer (OSut::collinears)"
 
     # Invalid case - raise DEBUG message, yet returns valid collinears.
-    collinears = mod1.getCollinears([p0, p1, p3, p8], "osut")
-    expect(collinears).to be_a(OpenStudio::Point3dVector)
-    expect(collinears.size).to eq(1)
-    expect(collinears[0]).to eq(p0)
+    colls = mod1.collinears([p0, p1, p3, p8], "osut")
+    expect(colls).to be_a(OpenStudio::Point3dVector)
+    expect(colls.size).to eq(1)
+    expect(colls[0]).to eq(p0)
     expect(mod1.debug?).to be true
     expect(mod1.logs.size).to eq(1)
     expect(mod1.logs.first[:message]).to eq(m0)
     expect(mod1.clean!).to eq(DBG)
 
     # Valid, basic case
-    collinears = mod1.getCollinears([p0, p1, p3, p8])
-    expect(collinears.size).to eq(1)
-    expect(collinears[0]).to eq(p0)                     # same object ID
-    expect(mod1.same?(collinears.first, p0)).to be true # more expensive way
+    colls = mod1.collinears([p0, p1, p3, p8])
+    expect(colls.size).to eq(1)
+    expect(colls[0]).to eq(p0)                     # same object ID
+    expect(mod1.same?(colls.first, p0)).to be true # more expensive way
 
-    collinears = mod1.getCollinears([p0, p1, p3, p8], 0)
-    expect(collinears.size).to eq(1)
-    expect(collinears[0]).to eq(p0)
+    colls = mod1.collinears([p0, p1, p3, p8], 0)
+    expect(colls.size).to eq(1)
+    expect(colls[0]).to eq(p0)
 
-    collinears = mod1.getCollinears([p0, p1, p2, p3, p8])
-    expect(collinears.size).to eq(2)
-    expect(collinears[ 0]).to eq(p0)
-    expect(collinears[-1]).to eq(p1)
+    colls = mod1.collinears([p0, p1, p2, p3, p8])
+    expect(colls.size).to eq(2)
+    expect(colls[ 0]).to eq(p0)
+    expect(colls[-1]).to eq(p1)
     expect(mod1.pointAlongSegment?(p0, sgs.first)) # sg is an Array (size = 2)
 
     # Only 2 collinears, so request for first 3 is ignored.
-    collinears = mod1.getCollinears([p0, p1, p2, p3, p8], 3)
-    expect(collinears.size).to eq(2)
-    expect(mod1.same?(collinears[0], p0)).to be true
-    expect(mod1.same?(collinears[1], p1)).to be true
+    colls = mod1.collinears([p0, p1, p2, p3, p8], 3)
+    expect(colls.size).to eq(2)
+    expect(mod1.same?(colls[0], p0)).to be true
+    expect(mod1.same?(colls[1], p1)).to be true
 
     # First collinear (out of 2).
-    collinears = mod1.getCollinears([p0, p1, p2, p3, p8], 1)
+    collinears = mod1.collinears([p0, p1, p2, p3, p8], 1)
     expect(collinears.size).to eq(1)
     expect(mod1.same?(collinears[0], p0)).to be true
 
     # Last collinear (out of 2).
-    collinears = mod1.getCollinears([p0, p1, p2, p3, p8], -1)
-    expect(collinears.size).to eq(1)
-    expect(mod1.same?(collinears[0], p1)).to be true
+    colls = mod1.collinears([p0, p1, p2, p3, p8], -1)
+    expect(colls.size).to eq(1)
+    expect(mod1.same?(colls[0], p1)).to be true
 
     # First two vs last two: same result.
-    collinears = mod1.getCollinears([p0, p1, p2, p3, p8], -2)
-    expect(collinears.size).to eq(2)
-    expect(mod1.same?(collinears[0], p0)).to be true
-    expect(mod1.same?(collinears[1], p1)).to be true
+    colls = mod1.collinears([p0, p1, p2, p3, p8], -2)
+    expect(colls.size).to eq(2)
+    expect(mod1.same?(colls[0], p0)).to be true
+    expect(mod1.same?(colls[1], p1)).to be true
 
     # Ignore n request when n.abs > number of actual collinears.
-    collinears = mod1.getCollinears([p0, p1, p2, p3, p8], 6)
-    expect(collinears.size).to eq(2)
-    expect(mod1.same?(collinears[0], p0)).to be true
-    expect(mod1.same?(collinears[1], p1)).to be true
+    colls = mod1.collinears([p0, p1, p2, p3, p8], 6)
+    expect(colls.size).to eq(2)
+    expect(mod1.same?(colls[0], p0)).to be true
+    expect(mod1.same?(colls[1], p1)).to be true
 
-    collinears = mod1.getCollinears([p0, p1, p2, p3, p8], -6)
-    expect(collinears.size).to eq(2)
-    expect(mod1.same?(collinears[0], p0)).to be true
-    expect(mod1.same?(collinears[1], p1)).to be true
+    colls = mod1.collinears([p0, p1, p2, p3, p8], -6)
+    expect(colls.size).to eq(2)
+    expect(mod1.same?(colls[0], p0)).to be true
+    expect(mod1.same?(colls[1], p1)).to be true
 
     # Stress test pointAlongSegment?
     m0 = "'points' String? expecting Array (OSut::to_p3Dv)"
@@ -2981,41 +2981,41 @@ RSpec.describe OSut do
 
     # CASE a1: 2x end-to-end line segments (returns matching endpoints).
     expect(mod1.lineIntersects?(   [p0, p1], [p1, p2] )).to be true
-    pt = mod1.getLineIntersection( [p0, p1], [p1, p2] )
+    pt = mod1.lineIntersection( [p0, p1], [p1, p2] )
     expect(mod1.same?(pt, p1)).to be true
 
     # CASE a2: as a1, sequence of line segment endpoints doesn't matter.
     expect(mod1.lineIntersects?(   [p1, p0], [p1, p2] )).to be true
-    pt = mod1.getLineIntersection( [p1, p0], [p1, p2] )
+    pt = mod1.lineIntersection( [p1, p0], [p1, p2] )
     expect(mod1.same?(pt, p1)).to be true
 
     # CASE b1: 2x right-angle line segments, with 1x matching at corner.
     expect(mod1.lineIntersects?(   [p1, p2], [p1, p3] )).to be true
-    pt = mod1.getLineIntersection( [p1, p2], [p2, p3] )
+    pt = mod1.lineIntersection( [p1, p2], [p2, p3] )
     expect(mod1.same?(pt, p2)).to be true
 
     # CASE b2: as b1, sequence of segments doesn't matter.
     expect(mod1.lineIntersects?(   [p2, p3], [p1, p2] )).to be true
-    pt = mod1.getLineIntersection( [p2, p3], [p1, p2] )
+    pt = mod1.lineIntersection( [p2, p3], [p1, p2] )
     expect(mod1.same?(pt, p2)).to be true
 
     # CASE c: 2x right-angle line segments, yet disconnected.
     expect(mod1.lineIntersects?(     [p0, p1], [p2, p3] )).to be false
-    expect(mod1.getLineIntersection( [p0, p1], [p2, p3] )).to be_nil
+    expect(mod1.lineIntersection( [p0, p1], [p2, p3] )).to be_nil
 
     # CASE d: 2x connected line segments, acute angle.
     expect(mod1.lineIntersects?(   [p0, p2], [p3, p0] )).to be true
-    pt = mod1.getLineIntersection( [p0, p2], [p3, p0] )
+    pt = mod1.lineIntersection( [p0, p2], [p3, p0] )
     expect(mod1.same?(pt, p0)).to be true
 
     # CASE e1: 2x disconnected line segments, right angle.
     expect(mod1.lineIntersects?(   [p0, p2], [p4, p6] )).to be true
-    pt = mod1.getLineIntersection( [p0, p2], [p4, p6] )
+    pt = mod1.lineIntersection( [p0, p2], [p4, p6] )
     expect(mod1.same?(pt, p5)).to be true
 
     # CASE e2: as e1, sequence of line segment endpoints doesn't matter.
     expect(mod1.lineIntersects?(   [p0, p2], [p6, p4] )).to be true
-    pt = mod1.getLineIntersection( [p0, p2], [p6, p4] )
+    pt = mod1.lineIntersection( [p0, p2], [p6, p4] )
     expect(mod1.same?(pt, p5)).to be true
 
     # Point ENTIRELY within (vs outside) a polygon.
@@ -3065,13 +3065,13 @@ RSpec.describe OSut do
     vtx << OpenStudio::Point3d.new( 0,  0, 10)
     vtx << OpenStudio::Point3d.new( 0,  0,  0)
 
-    segments = mod1.getSegments(vtx)
-    expect(segments).to be_a(OpenStudio::Point3dVectorVector)
-    expect(segments.size).to eq(3)
+    sgments = mod1.segments(vtx)
+    expect(sgments).to be_a(OpenStudio::Point3dVectorVector)
+    expect(sgments.size).to eq(3)
 
-    segments.each_with_index do |segment, i|
-      unless mod1.xyz?(segment, :x, segment[0].x)
-        vplane = mod1.verticalPlane(segment[0], segment[-1])
+    sgments.each_with_index do |sgment, i|
+      unless mod1.xyz?(sgment, :x, sgment[0].x)
+        vplane = mod1.verticalPlane(sgment[0], sgment[-1])
         expect(vplane).to be_a(OpenStudio::Plane)
       end
     end
@@ -4629,7 +4629,7 @@ RSpec.describe OSut do
     # "Story 1 West Perimeter Space"  : "Surface 6"
 
     model.getSpaces.each do |space|
-      rufs = mod1.getRoofs(space)
+      rufs = mod1.roofs(space)
       expect(rufs.size).to eq(1)
       ruf = rufs.first
       expect(ruf).to be_a(OpenStudio::Model::Surface)
@@ -4676,7 +4676,7 @@ RSpec.describe OSut do
     model.getSpaces.each do |space|
       next unless space.partofTotalFloorArea
 
-      rufs = mod1.getRoofs(space)
+      rufs = mod1.roofs(space)
       expect(rufs.size).to eq(1)
       ruf = rufs.first
       expect(ruf).to be_a(OpenStudio::Model::Surface)
@@ -4800,7 +4800,7 @@ RSpec.describe OSut do
     ld2 = OpenStudio::Point3d.new( 8,  3, 0)
     sg1 = OpenStudio::Point3d.new(12, 14, 0)
     sg2 = OpenStudio::Point3d.new(12,  6, 0)
-    expect(mod1.getLineIntersection([sg1, sg2], [ld1, ld2])).to be_nil
+    expect(mod1.lineIntersection([sg1, sg2], [ld1, ld2])).to be_nil
 
     # To support multiple polygon inserts within a larger polygon, subset boxes
     # must be first 'aligned' (along a temporary XY plane) in a systematic way
@@ -4997,7 +4997,7 @@ RSpec.describe OSut do
 
     # TOTAL attic roof area, including overhangs.
     roofs  = mod1.facets(attic, "Outdoors", "RoofCeiling")
-    rufs   = mod1.getRoofs(model.getSpaces)
+    rufs   = mod1.roofs(model.getSpaces)
     total1 = roofs.sum(&:grossArea)
     total2 = rufs.sum(&:grossArea)
     expect(total1.round(2)).to eq(total2.round(2))
@@ -5064,11 +5064,11 @@ RSpec.describe OSut do
     expect((tot1 - net).round(2)).to eq(sky_area1.round(2))
 
     # In absence of skylight wells (more importantly, in absence of leader lines
-    # anchoring skylight base surfaces), OSut's 'getRoofs' & 'grossRoofArea'
+    # anchoring skylight base surfaces), OSut's 'roofs' & 'grossRoofArea'
     # report not only on newly-added base surfaces (or their areas), but also
     # overalpping areas of attic roofs above. Unfortunately, these become
     # unreliable with newly-added skylight wells.
-    rfs2 = mod1.getRoofs(core)
+    rfs2 = mod1.roofs(core)
     tot2 = rfs2.sum(&:grossArea)
     expect(tot2.round(2)).to eq(tot1.round(2))
     expect(tot2.round(2)).to eq(mod1.grossRoofArea(core).round(2))
@@ -5086,11 +5086,11 @@ RSpec.describe OSut do
     # if a higher-level application, relying on 'addSkylights' (e.g. an
     # OpenStudio measure), stores its output for subsequent reporting purposes.
 
-    # Deeper dive: Why are OSut's 'getRoofs' and 'grossRoofArea' unreliable
+    # Deeper dive: Why are OSut's 'roofs' and 'grossRoofArea' unreliable
     # with leader lines? Both rely on OSut's 'overlaps?', itself relying on
     # OpenStudio's 'join' and 'intersect': if neither are successful in joining
     # (or intersecting) 2x polygons (e.g. attic roof vs cast core ceiling),
-    # there can be no identifiable overlap. In such cases, both 'getRoofs' and
+    # there can be no identifiable overlap. In such cases, both 'roofs' and
     # 'grossRoofArea' ignore overlapping attic roofs. A demo:
     roof_north   = model.getSurfaceByName("Attic_roof_north")
     core_ceiling = model.getSurfaceByName("Core_ZN_ceiling")
@@ -5119,11 +5119,11 @@ RSpec.describe OSut do
     expect(OpenStudio.join(a_roof_north, c_core_ceiling, TOL2)).to be_empty
     expect(OpenStudio.intersect(a_roof_north, c_core_ceiling, TOL)).to be_empty
 
-    # A future revision of OSut's 'getRoofs' and 'grossRoofArea' would require:
+    # A future revision of OSut's 'roofs' and 'grossRoofArea' would require:
     #   - a new method identifying leader lines amongts surface vertices
     #   - a new method identifying surface cutouts amongst surface vertices
     #   - a method to purge both leader lines and cutouts from surface vertices
-    #   - have 'getRoofs' & 'grossRoofArea' rely on the remaining outer vertices
+    #   - have 'roofs' & 'grossRoofArea' rely on the remaining outer vertices
     #     ... @todo?
 
     # --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- #
@@ -5348,8 +5348,8 @@ RSpec.describe OSut do
     gra_bulk = mod1.grossRoofArea(bulk)
     gra_fine = mod1.grossRoofArea(fine)
 
-    bulk_roof_m2 = mod1.getRoofs(bulk).sum(&:grossArea)
-    fine_roof_m2 = mod1.getRoofs(fine).sum(&:grossArea)
+    bulk_roof_m2 = mod1.roofs(bulk).sum(&:grossArea)
+    fine_roof_m2 = mod1.roofs(fine).sum(&:grossArea)
     expect(gra_bulk.round(2)).to eq(bulk_roof_m2.round(2))
     expect(gra_fine.round(2)).to eq(fine_roof_m2.round(2))
 

--- a/spec/osut_tests_spec.rb
+++ b/spec/osut_tests_spec.rb
@@ -5785,8 +5785,8 @@ RSpec.describe OSut do
     # corridors with multiple concavities).
     expect(mod1.spaceHeight(fine)).to be_within(TOL).of(8.53)
     expect(mod1.spaceWidth(fine)).to be_within(TOL).of(21.33)
-    expect(mod1.status).to eq(0)
 
+    # --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- #
     file  = File.join(__dir__, "files/osms/out/seb_sky.osm")
     path  = OpenStudio::Path.new(file)
     model = translator.loadModel(path)
@@ -5804,6 +5804,8 @@ RSpec.describe OSut do
     expect(mod1.alignedHeight(floor)).to be_within(TOL).of(6.88)
     expect(mod1.alignedWidth(floor)).to be_within(TOL).of(8.22)
     expect(mod1.spaceHeight(openarea)).to be_within(TOL).of(3.96)
-    expect(mod1.spaceWidth(openarea)).to be_within(TOL).of(7.90)
+    expect(mod1.spaceWidth(openarea)).to be_within(TOL).of(3.77)
+
+    expect(mod1.status).to eq(0)
   end
 end

--- a/spec/osut_tests_spec.rb
+++ b/spec/osut_tests_spec.rb
@@ -5743,7 +5743,7 @@ RSpec.describe OSut do
 
     # The Fine Storage space has 2 floors, at different Z-axis levels:
     # - main ground floor (slab on grade), Z=0.00m
-    # - a mezzanine floor, adjacent to the office space ceiling below, Z=4.27m
+    # - mezzanine floor, adjacent to the office space ceiling below, Z=4.27m
     expect(mod1.facets(fine, "all", "floor").size).to eq(2)
     groundfloor = model.getSurfaceByName("Fine Storage Floor")
     mezzanine   = model.getSurfaceByName("Office Roof Reversed")
@@ -5755,10 +5755,10 @@ RSpec.describe OSut do
     # The ground floor is L-shaped, floor surfaces have differenet Z=axis
     # levels, etc. In the context of codes/standards like ASHRAE 90.1 or the
     # Canadian NECB, determining what constitutes a space's 'height' and/or
-    # 'width' can matter, namely with regards to geometry-based LPD rules (e.g.
-    # adjustments per corridor 'width'). Not stating here what the definitive
-    # answers should be in all cases. There are however a few OSut functions
-    # that may be useful.
+    # 'width' matters, namely with regards to geometry-based LPD rules (e.g.
+    # adjustments based on corridor 'width'). Not stating here what the
+    # definitive answers should be in all cases. There are however a few OSut
+    # functions that may be helpful.
     #
     # OSut's 'aligned' height and width functions were initially developed for
     # non-flat surfaces, like walls and sloped roofs - particularly useful when
@@ -5778,11 +5778,13 @@ RSpec.describe OSut do
 
     # OSut's 'spaceHeight' and 'spaceWidth' are more suitable for height- or
     # width-based LPD adjustement calculations. OSut sets a space's width as
-    # the widest edge of the largest bounded box it can fit within a collection
-    # of neighbouring floor surfaces. This is considered reasonable for a long
-    # corridor, with a varying width along its full length. Achtung! The
-    # function can be time consuming for very convoluted spaces (e.g. long
-    # corridors with multiple concavities).
+    # the length of the narrowest edge of the largest bounded box that fits
+    # within a collection of neighbouring floor surfaces. This is considered
+    # reasonable for a long corridor, with varying widths along its full
+    # length (e.g. occasional alcoves).
+    #
+    # Achtung! The function can be time consuming (multiple iterations) for
+    # very convoluted spaces (e.g. long corridors with multiple concavities).
     expect(mod1.spaceHeight(fine)).to be_within(TOL).of(8.53)
     expect(mod1.spaceWidth(fine)).to be_within(TOL).of(21.33)
 


### PR DESCRIPTION
Related to this _pyOSut_ [PR](https://github.com/rd2/pyOSut/pull/7).

Around 40-odd typos (and other oddities) were identified in this Ruby implementation of _OSut_, while developing a Python counterpart, _pyOSut_. In some cases, these are simple fixes (no impact on the Python implementation). In other cases (like this first commit), they reveal weaknesses (to fix), such as not adequately catching bad user input. Over the next day or so, a number of such fixes are expected to be introduced, before re-releasing an upcoming OSut v0.6.1.